### PR TITLE
chore: don't use `Rc` around http client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -27,8 +27,8 @@ use cosmos_sdk_proto::traits::MessageExt;
 use cosmrs::tendermint::chain;
 use cosmrs::tx::{Fee, SignDoc, SignerInfo};
 use std::ops::{DivAssign, MulAssign};
-use std::rc::Rc;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::thread::sleep;
 use std::time::Duration;
 use tendermint_rpc::{Client, HttpClient};
@@ -65,7 +65,7 @@ impl Rpc {
     /// Will return `Err` if :
     /// - rpc server is down or invalid
     pub async fn new(url: &str) -> Result<Self, CosmosClient> {
-        let rpc = Rc::new(HttpClient::new(url)?);
+        let rpc = Arc::new(HttpClient::new(url)?);
 
         Ok(Rpc {
             chain_id: rpc.status().await?.node_info.network.to_string(),

--- a/src/client/auth.rs
+++ b/src/client/auth.rs
@@ -6,16 +6,16 @@ use cosmos_sdk_proto::cosmos::auth::v1beta1::{
 };
 use cosmos_sdk_proto::cosmos::base::query::v1beta1::PageRequest;
 use prost::Message;
-use std::rc::Rc;
+use std::sync::Arc;
 use tendermint::abci::Code;
 use tendermint_rpc::{Client, HttpClient};
 
 pub struct Module {
-    rpc: Rc<HttpClient>,
+    rpc: Arc<HttpClient>,
 }
 
 impl Module {
-    pub fn new(rpc: Rc<HttpClient>) -> Self {
+    pub fn new(rpc: Arc<HttpClient>) -> Self {
         Module { rpc }
     }
 

--- a/src/client/authz.rs
+++ b/src/client/authz.rs
@@ -6,16 +6,16 @@ use cosmos_sdk_proto::cosmos::authz::v1beta1::{
 };
 use cosmos_sdk_proto::cosmos::base::query::v1beta1::PageRequest;
 use prost::Message;
-use std::rc::Rc;
+use std::sync::Arc;
 use tendermint::abci::Code;
 use tendermint_rpc::{Client, HttpClient};
 
 pub struct Module {
-    rpc: Rc<HttpClient>,
+    rpc: Arc<HttpClient>,
 }
 
 impl Module {
-    pub fn new(rpc: Rc<HttpClient>) -> Self {
+    pub fn new(rpc: Arc<HttpClient>) -> Self {
         Module { rpc }
     }
 

--- a/src/client/bank.rs
+++ b/src/client/bank.rs
@@ -9,16 +9,16 @@ use cosmos_sdk_proto::cosmos::bank::v1beta1::{
 };
 use cosmos_sdk_proto::cosmos::base::query::v1beta1::PageRequest;
 use prost::Message;
-use std::rc::Rc;
+use std::sync::Arc;
 use tendermint::abci::Code;
 use tendermint_rpc::{Client, HttpClient};
 
 pub struct Module {
-    rpc: Rc<HttpClient>,
+    rpc: Arc<HttpClient>,
 }
 
 impl Module {
-    pub fn new(rpc: Rc<HttpClient>) -> Self {
+    pub fn new(rpc: Arc<HttpClient>) -> Self {
         Module { rpc }
     }
 

--- a/src/client/distribution.rs
+++ b/src/client/distribution.rs
@@ -12,16 +12,16 @@ use cosmos_sdk_proto::cosmos::distribution::v1beta1::{
     QueryValidatorSlashesRequest, QueryValidatorSlashesResponse,
 };
 use prost::Message;
-use std::rc::Rc;
+use std::sync::Arc;
 use tendermint::abci::Code;
 use tendermint_rpc::{Client, HttpClient};
 
 pub struct Module {
-    rpc: Rc<HttpClient>,
+    rpc: Arc<HttpClient>,
 }
 
 impl Module {
-    pub fn new(rpc: Rc<HttpClient>) -> Self {
+    pub fn new(rpc: Arc<HttpClient>) -> Self {
         Module { rpc }
     }
 

--- a/src/client/evidence.rs
+++ b/src/client/evidence.rs
@@ -5,16 +5,16 @@ use cosmos_sdk_proto::cosmos::evidence::v1beta1::{
     QueryAllEvidenceRequest, QueryAllEvidenceResponse, QueryEvidenceRequest, QueryEvidenceResponse,
 };
 use prost::Message;
-use std::rc::Rc;
+use std::sync::Arc;
 use tendermint::abci::Code;
 use tendermint_rpc::{Client, HttpClient};
 
 pub struct Module {
-    rpc: Rc<HttpClient>,
+    rpc: Arc<HttpClient>,
 }
 
 impl Module {
-    pub fn new(rpc: Rc<HttpClient>) -> Self {
+    pub fn new(rpc: Arc<HttpClient>) -> Self {
         Module { rpc }
     }
 

--- a/src/client/feegrant.rs
+++ b/src/client/feegrant.rs
@@ -5,16 +5,16 @@ use cosmos_sdk_proto::cosmos::feegrant::v1beta1::{
     QueryAllowanceRequest, QueryAllowanceResponse, QueryAllowancesRequest, QueryAllowancesResponse,
 };
 use prost::Message;
-use std::rc::Rc;
+use std::sync::Arc;
 use tendermint::abci::Code;
 use tendermint_rpc::{Client, HttpClient};
 
 pub struct Module {
-    rpc: Rc<HttpClient>,
+    rpc: Arc<HttpClient>,
 }
 
 impl Module {
-    pub fn new(rpc: Rc<HttpClient>) -> Self {
+    pub fn new(rpc: Arc<HttpClient>) -> Self {
         Module { rpc }
     }
 

--- a/src/client/gov.rs
+++ b/src/client/gov.rs
@@ -9,16 +9,16 @@ use cosmos_sdk_proto::cosmos::gov::v1beta1::{
     QueryVotesResponse,
 };
 use prost::Message;
-use std::rc::Rc;
+use std::sync::Arc;
 use tendermint::abci::Code;
 use tendermint_rpc::{Client, HttpClient};
 
 pub struct Module {
-    rpc: Rc<HttpClient>,
+    rpc: Arc<HttpClient>,
 }
 
 impl Module {
-    pub fn new(rpc: Rc<HttpClient>) -> Self {
+    pub fn new(rpc: Arc<HttpClient>) -> Self {
         Module { rpc }
     }
 

--- a/src/client/mint.rs
+++ b/src/client/mint.rs
@@ -5,16 +5,16 @@ use cosmos_sdk_proto::cosmos::mint::v1beta1::{
     QueryInflationResponse, QueryParamsRequest, QueryParamsResponse,
 };
 use prost::Message;
-use std::rc::Rc;
+use std::sync::Arc;
 use tendermint::abci::Code;
 use tendermint_rpc::{Client, HttpClient};
 
 pub struct Module {
-    rpc: Rc<HttpClient>,
+    rpc: Arc<HttpClient>,
 }
 
 impl Module {
-    pub fn new(rpc: Rc<HttpClient>) -> Self {
+    pub fn new(rpc: Arc<HttpClient>) -> Self {
         Module { rpc }
     }
 

--- a/src/client/params.rs
+++ b/src/client/params.rs
@@ -2,16 +2,16 @@ use crate::error::CosmosClient;
 use crate::error::CosmosClient::{ProstDecodeError, RpcError};
 use cosmos_sdk_proto::cosmos::params::v1beta1::{QueryParamsRequest, QueryParamsResponse};
 use prost::Message;
-use std::rc::Rc;
+use std::sync::Arc;
 use tendermint::abci::Code;
 use tendermint_rpc::{Client, HttpClient};
 
 pub struct Module {
-    rpc: Rc<HttpClient>,
+    rpc: Arc<HttpClient>,
 }
 
 impl Module {
-    pub fn new(rpc: Rc<HttpClient>) -> Self {
+    pub fn new(rpc: Arc<HttpClient>) -> Self {
         Module { rpc }
     }
 

--- a/src/client/slashing.rs
+++ b/src/client/slashing.rs
@@ -6,16 +6,16 @@ use cosmos_sdk_proto::cosmos::slashing::v1beta1::{
     QuerySigningInfosRequest, QuerySigningInfosResponse,
 };
 use prost::Message;
-use std::rc::Rc;
+use std::sync::Arc;
 use tendermint::abci::Code;
 use tendermint_rpc::{Client, HttpClient};
 
 pub struct Module {
-    rpc: Rc<HttpClient>,
+    rpc: Arc<HttpClient>,
 }
 
 impl Module {
-    pub fn new(rpc: Rc<HttpClient>) -> Self {
+    pub fn new(rpc: Arc<HttpClient>) -> Self {
         Module { rpc }
     }
 

--- a/src/client/staking.rs
+++ b/src/client/staking.rs
@@ -14,16 +14,16 @@ use cosmos_sdk_proto::cosmos::staking::v1beta1::{
     QueryValidatorUnbondingDelegationsResponse, QueryValidatorsRequest, QueryValidatorsResponse,
 };
 use prost::Message;
-use std::rc::Rc;
+use std::sync::Arc;
 use tendermint::abci::Code;
 use tendermint_rpc::{Client, HttpClient};
 
 pub struct Module {
-    rpc: Rc<HttpClient>,
+    rpc: Arc<HttpClient>,
 }
 
 impl Module {
-    pub fn new(rpc: Rc<HttpClient>) -> Self {
+    pub fn new(rpc: Arc<HttpClient>) -> Self {
         Module { rpc }
     }
 

--- a/src/client/tx.rs
+++ b/src/client/tx.rs
@@ -4,7 +4,7 @@ use cosmos_sdk_proto::cosmos::tx::v1beta1::{
     BroadcastMode, GetTxRequest, GetTxResponse, SimulateRequest, SimulateResponse,
 };
 use prost::Message;
-use std::rc::Rc;
+use std::sync::Arc;
 use tendermint::abci::Code;
 use tendermint_rpc::endpoint::broadcast::{tx_async, tx_commit, tx_sync};
 use tendermint_rpc::{Client, HttpClient};
@@ -17,11 +17,11 @@ pub enum Response {
 }
 
 pub struct Module {
-    rpc: Rc<HttpClient>,
+    rpc: Arc<HttpClient>,
 }
 
 impl Module {
-    pub fn new(rpc: Rc<HttpClient>) -> Self {
+    pub fn new(rpc: Arc<HttpClient>) -> Self {
         Module { rpc }
     }
 

--- a/src/client/upgrade.rs
+++ b/src/client/upgrade.rs
@@ -6,16 +6,16 @@ use cosmos_sdk_proto::cosmos::upgrade::v1beta1::{
     QueryUpgradedConsensusStateResponse,
 };
 use prost::Message;
-use std::rc::Rc;
+use std::sync::Arc;
 use tendermint::abci::Code;
 use tendermint_rpc::{Client, HttpClient};
 
 pub struct Module {
-    rpc: Rc<HttpClient>,
+    rpc: Arc<HttpClient>,
 }
 
 impl Module {
-    pub fn new(rpc: Rc<HttpClient>) -> Self {
+    pub fn new(rpc: Arc<HttpClient>) -> Self {
         Module { rpc }
     }
 

--- a/src/client/wasm.rs
+++ b/src/client/wasm.rs
@@ -12,16 +12,16 @@ use cosmos_sdk_proto::cosmwasm::wasm::v1::{
 use prost::Message;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use std::rc::Rc;
+use std::sync::Arc;
 use tendermint::abci::Code;
 use tendermint_rpc::{Client, HttpClient};
 
 pub struct Module {
-    rpc: Rc<HttpClient>,
+    rpc: Arc<HttpClient>,
 }
 
 impl Module {
-    pub fn new(rpc: Rc<HttpClient>) -> Self {
+    pub fn new(rpc: Arc<HttpClient>) -> Self {
         Module { rpc }
     }
 


### PR DESCRIPTION
This uses `Arc` rather than `Rc` around the http client. By using `Rc` this constraints too much where you can use the `Rpc` type since you can't use it in any threaded contexts as they require the type to be `Send`.